### PR TITLE
Change non-primitive arrays to return nil with parsing error. 

### DIFF
--- a/Serializable/Source/Serializable.swift
+++ b/Serializable/Source/Serializable.swift
@@ -75,7 +75,7 @@ public extension Keymappable {
 	public func mapped<T where T:_ArrayType, T:CollectionType, T.Generator.Element: Decodable>(dictionary: NSDictionary?, key: String) -> T? {
 		
 		guard let dict = dictionary else {
-			return T()
+			return nil
 		}
 		
 		let sourceOpt = dict[key]
@@ -86,7 +86,7 @@ public extension Keymappable {
             return finalArray
         }
 
-        return T()
+        return nil
 	}
 	
     /**
@@ -213,7 +213,7 @@ public extension Keymappable {
     public func mapped<T where T:_ArrayType, T:CollectionType, T.Generator.Element: RawRepresentable>(dictionary: NSDictionary?, key: String) -> T? {
         
         guard let dict = dictionary else {
-            return T()
+            return nil
         }
         
         let sourceOpt = dict[key]
@@ -223,6 +223,6 @@ public extension Keymappable {
             return (finalArray as! T)
         }
         
-        return T()
+        return nil
     }
 }

--- a/SerializableTests/Tests/SerializableEnumsTests.swift
+++ b/SerializableTests/Tests/SerializableEnumsTests.swift
@@ -46,15 +46,15 @@ class SerializableEnumsTests: XCTestCase {
         XCTAssertEqual(testModel.stringEnumArray, [StringEnum.Value1, StringEnum.DifferentValue], "String enum array test failed!")
         XCTAssertEqual(testModel.optionalStringEnumArray!, [StringEnum.Value1, StringEnum.DifferentValue], "Optional string enum array test failed!")
         XCTAssertEqual(testModel.optionalStringEnumArrayWithDefaultValue!, [StringEnum.Value1, StringEnum.DifferentValue], "Optional string enum array with default value test failed!")
-        XCTAssertEqual(testModel.nonExistentStringEnumArray!, [StringEnum](), "Optional string enum array with non existent value test failed!")
-        XCTAssertEqual(testModel.wrongTypeStringEnumArray!, [StringEnum](), "Wrong type string enum array test failed!")
+        XCTAssertNil(testModel.nonExistentStringEnumArray, "Optional string enum array with non existent value test failed!")
+        XCTAssertNil(testModel.wrongTypeStringEnumArray, "Wrong type string enum array test failed!")
     }
 
     func testDoubleEnumArrayParsing() {
         XCTAssertEqual(testModel.doubleEnumArray, [DoubleEnum.Value1, DoubleEnum.DifferentValue], "Double enum array test failed!")
         XCTAssertEqual(testModel.optionalDoubleEnumArray!, [DoubleEnum.Value1, DoubleEnum.DifferentValue], "Optional double enum array test failed!")
         XCTAssertEqual(testModel.optionalDoubleEnumArrayWithDefaultValue!, [DoubleEnum.Value1, DoubleEnum.DifferentValue], "Optional double enum array with default value test failed!")
-        XCTAssertEqual(testModel.nonExistentDoubleEnumArray!, [DoubleEnum](), "Optional double enum array with non existent value test failed!")
-        XCTAssertEqual(testModel.wrongTypeDoubleEnumArray!, [DoubleEnum](),"Wrong type double enum array test failed!")
+        XCTAssertNil(testModel.nonExistentDoubleEnumArray, "Optional double enum array with non existent value test failed!")
+        XCTAssertNil(testModel.wrongTypeDoubleEnumArray,"Wrong type double enum array test failed!")
     }
 }

--- a/SerializableTests/Tests/SerializableNilEntitiesTests.swift
+++ b/SerializableTests/Tests/SerializableNilEntitiesTests.swift
@@ -31,8 +31,8 @@ class SerializableNilEntitiesTests: XCTestCase {
 		XCTAssertNotNil(testModel.names, "Guard statement failed for Serializable array with nil Dictionary")
 		XCTAssertEqual(testModel.names.count, 0, "Guard statement failed for Serializable array with nil Dictionary")
 		XCTAssertNil(testModel.optionalName, "Guard statement failed for optional Serializable with nil Dictionary")
-		XCTAssertNotNil(testModel.optionalNames, "Guard statement failed for optional Serializable array with nil Dictionary")
-		XCTAssertEqual(testModel.optionalNames?.count, 0, "Guard statement failed for optional Serializable array with nil Dictionary")
+		XCTAssertNil(testModel.optionalNames, "Guard statement failed for optional Serializable array with nil Dictionary")
+		
 	}
 	
 	func testNilEnums() {
@@ -40,8 +40,7 @@ class SerializableNilEntitiesTests: XCTestCase {
 		XCTAssertNotNil(testModel.someEnumArray, "Guard statement failed for Enum array with nil dictionary")
 		XCTAssertEqual(testModel.someEnumArray.count, 0, "Guard statement failed for Enum array with nil dictionary")
 		XCTAssertNil(testModel.optionalEnum, "Guard statement failed for optional Enum with nil dictionary")
-		XCTAssertNotNil(testModel.optionalEnumArray, "Guard statement failed for optional Enum array with nil dictionary")
-		XCTAssertEqual(testModel.optionalEnumArray?.count, 0, "Guard statement failed for optional Enum array with nil dictionary")
+		XCTAssertNil(testModel.optionalEnumArray, "Guard statement failed for optional Enum array with nil dictionary")
 	}
 	
 	func testNilStringInitializables() {


### PR DESCRIPTION
Change Serializable and RawRepresentable arrays to return nil instead of [] if parsing fails. This is consistent with Primitive type arrays, which currently return nil. 

`var someArray: [SomeSerializable]?` is marked as optional, so I expect that it can be nil and can handle it appropriately. Returning an empty array if parsing fails is unexpected and can actually introduce bugs if I want to handle array.count == 0 and array == nil differently, e.g. showing an empty list vs not showing the list at all. 

This also increases code coverage to 100%, so think about that :smiley_cat: 
