### PR TITLE
Alamofire extension update

### DIFF
--- a/Serializable/Serializable/Classes/Extensions/AlamofireExtension.swift
+++ b/Serializable/Serializable/Classes/Extensions/AlamofireExtension.swift
@@ -131,10 +131,12 @@ public extension Alamofire.Request
      
      - returns: The request
      */
-    public typealias NilSerializable = AnyObject
+    
     
     public func responseSerializable(completionHandler: Response<NilSerializable, NSError> -> Void) -> Self {
         return validate().responseJSON(completionHandler: completionHandler)
     }
     
 }
+// Convenience type for network requests with no response data
+public typealias NilSerializable = AnyObject

--- a/Serializable/Serializable/Classes/Extensions/AlamofireExtension.swift
+++ b/Serializable/Serializable/Classes/Extensions/AlamofireExtension.swift
@@ -41,7 +41,7 @@ public extension Parser {
                     let newError = NSError(domain: error.domain, code: error.code, userInfo: userInfo)
                     return .Failure(newError)
                 }
-
+                
                 return .Failure(error)
             }
         }
@@ -72,7 +72,7 @@ public extension Alamofire.Request
      
      - returns: The request
      */
-  
+    
     public func responseSerializable<T:Decodable>(completionHandler: Response<T, NSError> -> Void, unwrapper:Parser.Unwrapper = Parser.defaultUnwrapper) -> Self {
         let serializer = Parser.serializer(parsingHandler: {
             ( data: AnyObject? ) -> T? in
@@ -123,4 +123,18 @@ public extension Alamofire.Request
         
         return validate().response(responseSerializer: serializer, completionHandler: completionHandler)
     }
+    
+    /**
+     Convenience method for a handler that does not need to parse the results of the network request.
+     
+     - parameter completionHandler:A closure that is invoked when the request is finished
+     
+     - returns: The request
+     */
+    public typealias NilSerializable = AnyObject
+    
+    public func responseSerializable(completionHandler: Response<NilSerializable, NSError> -> Void) -> Self {
+        return validate().responseJSON(completionHandler: completionHandler)
+    }
+    
 }

--- a/Serializable/SerializableTests/Tests/AlamofireExtensionTests.swift
+++ b/Serializable/SerializableTests/Tests/AlamofireExtensionTests.swift
@@ -12,6 +12,8 @@ import Alamofire
 
 class AlamofireExtensionTests: XCTestCase {
 	
+    let timeoutDuration = 10.0
+    
 	let manager = Manager()
     
     override func setUp() {
@@ -33,7 +35,7 @@ class AlamofireExtensionTests: XCTestCase {
 			}
 		}
 		manager.request(.GET, "http://httpbin.org/get").responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	
 	func testAlamofireExtensionBadJSON() {
@@ -47,7 +49,7 @@ class AlamofireExtensionTests: XCTestCase {
 			}
 		}
 		manager.request(.GET, "http://httpbin.org/deny").responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 
 	
@@ -62,7 +64,7 @@ class AlamofireExtensionTests: XCTestCase {
 			}
 		}
 		manager.request(.GET, "http://httpbin.org/get").responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	func testAlamofireExtensionUnexpectedArrayJSON() {
 		let expectation = expectationWithDescription("Expected array data to single object from response")
@@ -75,7 +77,7 @@ class AlamofireExtensionTests: XCTestCase {
 			}
 		}
 		manager.request(.GET, "https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/ArrayTest.json").responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	func testAlamofireExtensionEmptyJSON() {
 		let expectation = expectationWithDescription("Expected empty response")
@@ -88,7 +90,7 @@ class AlamofireExtensionTests: XCTestCase {
 			}
 		}
 		manager.request(.GET, "https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/Empty.json").responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	func testAlamofireArrayUnwrapper() {
 		let expectation = expectationWithDescription("Expected unwrapped array response")
@@ -105,7 +107,7 @@ class AlamofireExtensionTests: XCTestCase {
 		manager.request(.GET,
 			"https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/NestedArrayTest.json")
 			.responseSerializable(handler, unwrapper: unwrapper)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	
 	func testAlamofireArrayNotUnwrapped() {
@@ -122,7 +124,7 @@ class AlamofireExtensionTests: XCTestCase {
 		manager.request(.GET,
 			"https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/NestedArrayTest.json")
 			.responseSerializable(handler)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
 	func testAlamofireWrongTypeUnwrapper() {
 		let expectation = expectationWithDescription("Expected unwrapped array response")
@@ -139,6 +141,20 @@ class AlamofireExtensionTests: XCTestCase {
 		manager.request(.GET,
 			"https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/NestedArrayTest.json")
 			.responseSerializable(handler, unwrapper: unwrapper)
-		waitForExpectationsWithTimeout(5, handler: nil)
+		waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
 	}
+    
+    func testAlamofireExtensionNonSerializable() {
+        let expectation = expectationWithDescription("Expected empty response")
+        let handler:(Alamofire.Response<NilSerializable, NSError>) -> Void = { result in
+            switch result.result {
+            case .Failure:
+                expectation.fulfill()
+            default:
+                break
+            }
+        }
+        manager.request(.GET, "https://raw.githubusercontent.com/nodes-ios/Serializable/master/Serializable/SerializableTests/TestEndpoint/Empty.json").responseSerializable(handler)
+        waitForExpectationsWithTimeout(timeoutDuration, handler: nil)
+    }
 }


### PR DESCRIPTION
Adds a convenience method and type so that responseSerializable can be used for requests with no response data.
