### PR TITLE
Mark all ruby files as Swift and ignore the Dependancies folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 Serializable.podspec linguist-documentation
 Serializable/Serializable.h linguist-documentation
+Serializable/Dependencies/* linguist-documentation
+*.rb linguist-language=Swift


### PR DESCRIPTION
Fix GitHub language detection by ignoring the Prebuild folder #61