### PR TITLE
Added support for a custom date format in StringInitializable

### DIFF
--- a/Serializable/Serializable/Classes/Extensions/Extensions.swift
+++ b/Serializable/Serializable/Classes/Extensions/Extensions.swift
@@ -29,9 +29,10 @@ extension URL: StringInitializable {
 extension Date: StringInitializable {
     static fileprivate let internalDateFormatter = DateFormatter()
     static fileprivate let allowedDateFormats = ["yyyy-MM-dd'T'HH:mm:ssZZZZZ", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"]
+	static public var customDateFormats: [String] = []
 
     public static func fromString<T>(_ string: String) -> T? {
-        for format in allowedDateFormats {
+        for format in allowedDateFormats + customDateFormats {
             internalDateFormatter.dateFormat = format
             if let date = internalDateFormatter.date(from: string) as? T {
                 return date

--- a/Serializable/SerializableTests/Models/StringInitializableTest.json
+++ b/Serializable/SerializableTests/Models/StringInitializableTest.json
@@ -3,5 +3,6 @@
 	"some_date" : "1974-08-15T15:17:14+00:00",
 	"some_empty_url" : "",
     "some_empty_date" : "",
-    "some_bad_date" :"WOW_SUCH_DATE_NOT_CORRECT"
+    "some_bad_date" :"WOW_SUCH_DATE_NOT_CORRECT",
+	"some_custom_date" : "2016-11-15 17:19:04"
 }

--- a/Serializable/SerializableTests/Models/StringInitializableTestModel.swift
+++ b/Serializable/SerializableTests/Models/StringInitializableTestModel.swift
@@ -15,24 +15,27 @@ struct StringInitializableTestModel {
     var someEmptyDate: Date?
     var someEmptyURL: URL? //<- some_empty_url
     var someBadDate: Date?
+	var someCustomDate: Date?
 }
 
 extension StringInitializableTestModel: Serializable {
-    init(dictionary: NSDictionary?) {
-        someUrl       <== (self, dictionary, "some_url")
-        someDate      <== (self, dictionary, "some_date")
-        someEmptyDate <== (self, dictionary, "some_empty_date")
-        someEmptyURL  <== (self, dictionary, "some_empty_url")
-        someBadDate   <== (self, dictionary, "some_bad_date")
-    }
-
-    func encodableRepresentation() -> NSCoding {
-        let dict = NSMutableDictionary()
-        (dict, "some_url")        <== someUrl
-        (dict, "some_date")       <== someDate
-        (dict, "some_empty_date") <== someEmptyDate
-        (dict, "some_empty_url")  <== someEmptyURL
-        (dict, "some_bad_date")   <== someBadDate
-        return dict
-    }
+	init(dictionary: NSDictionary?) {
+		someUrl        <== (self, dictionary, "some_url")
+		someDate       <== (self, dictionary, "some_date")
+		someEmptyDate  <== (self, dictionary, "some_empty_date")
+		someEmptyURL   <== (self, dictionary, "some_empty_url")
+		someBadDate    <== (self, dictionary, "some_bad_date")
+		someCustomDate <== (self, dictionary, "some_custom_date")
+	}
+	
+	func encodableRepresentation() -> NSCoding {
+		let dict = NSMutableDictionary()
+		(dict, "some_url")         <== someUrl
+		(dict, "some_date")        <== someDate
+		(dict, "some_empty_date")  <== someEmptyDate
+		(dict, "some_empty_url")   <== someEmptyURL
+		(dict, "some_bad_date")    <== someBadDate
+		(dict, "some_custom_date") <== someCustomDate
+		return dict
+	}
 }

--- a/Serializable/SerializableTests/Tests/StringInitializableTests.swift
+++ b/Serializable/SerializableTests/Tests/StringInitializableTests.swift
@@ -16,6 +16,7 @@ class StringInitializableTests: XCTestCase {
 		super.setUp()
 		do {
 			if let path = Bundle(for: type(of: self)).path(forResource: "StringInitializableTest", ofType: "json"), let data = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+				Date.customDateFormats = ["yyyy-MM-dd HH:mm:ss"]
 				let bridgedDictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? NSDictionary
 				testModel = StringInitializableTestModel(dictionary: bridgedDictionary)
 			}
@@ -37,6 +38,7 @@ class StringInitializableTests: XCTestCase {
         XCTAssertNil(testModel.someEmptyDate, "Failed to return nil when parsing empty date")
         XCTAssertNil(testModel.someBadDate, "Failed to return nil when parsing bad date")
         XCTAssertEqual(Date.fromString(testModel.someDate?.stringRepresentation() ?? ""), testModel.someDate, "String representation of URL differs.")
+		XCTAssertEqual(Date.fromString(testModel.someCustomDate?.stringRepresentation() ?? ""), testModel.someCustomDate, "String representation of custom URL differs.")
     }
     
     func testNSURLEncoding() {
@@ -59,5 +61,16 @@ class StringInitializableTests: XCTestCase {
             XCTFail("Failed to encode NSDate to String")
         }
     }
+	
+	func testCustomNSDateEncoding() {
+		guard let encodedModel = testModel.encodableRepresentation() as? NSDictionary else { XCTFail("encodableRepresentation() Failed"); return }
+		
+		if let someDateString = encodedModel["some_custom_date"] as? String {
+			let someDate = DateFormatter().date(from: someDateString)
+			XCTAssertEqual(someDate, DateFormatter().date(from: "2016-11-15 17:19:04"), "Failed to encode NSDate to String")
+		} else {
+			XCTFail("Failed to encode NSDate to String")
+		}
+	}
 }
 

--- a/Serializable/SerializableTests/Tests/StringInitializableTests.swift
+++ b/Serializable/SerializableTests/Tests/StringInitializableTests.swift
@@ -26,6 +26,11 @@ class StringInitializableTests: XCTestCase {
 		}
 	}
 	
+	override func tearDown() {
+		super.tearDown()
+		Date.customDateFormats = []
+	}
+	
 	func testNSURL() {
 		XCTAssertNotNil(testModel.someUrl, "Failed to create NSURL from string")
 		XCTAssertEqual(testModel.someUrl, URL(string: "http://www.google.com"), "Failed to parse URL")


### PR DESCRIPTION
Previously, if your date wasn't in one of those 3 formats, it wouldn't parse. This lets you add a custom format if your API doesn't use a "normal" format, and is more scalable than updating the entire framework every time someone has a new format. 