### PR TITLE
Updated podspec

### DIFF
--- a/Serpent.podspec
+++ b/Serpent.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Serpent"
-  s.version      = "1.0.1"
+  s.version      = "1.0.5"
   s.summary      = "A protocol to serialize Swift structs and classes for encoding and decoding."
   s.homepage     = "https://github.com/nodes-ios/Serpent"
   s.description  = <<-DESC


### PR DESCRIPTION
[Serpent 1.0.5](https://cocoapods.org/pods/Serpent) was released, so it makes sense for the podspec to be updated on master. Can't take this one through `develop` because `develop` has breaking changes that we don't want on `master` yet.