### PR TITLE
If we have a specific error on the serializer pass it on instead of m…

### DIFF
--- a/Serpent/Serpent/Classes/Extensions/AlamofireExtension.swift
+++ b/Serpent/Serpent/Classes/Extensions/AlamofireExtension.swift
@@ -21,8 +21,12 @@ public extension Parser {
     
     internal static func serializer<T>(_ parsingHandler: (( _ data: Any? ) -> T?)?) -> DataResponseSerializer<T> {
         return DataResponseSerializer<T> { (request, response, data, error) -> Result<T> in
-            
            
+            //If we have an error here - pass it on
+            if let error = error {
+                return .failure(error)
+            }
+
             let result = Request.serializeResponseJSON(options: .allowFragments, response: response, data: data, error: error)
             
             switch result {


### PR DESCRIPTION
…apping to parsing error (2048) always

At the moment we are not detecting connection errors. This pr tries to fix that by parsing the specific errorcode instead of mapping to 2048 on all errors.

Please review