### PR TITLE
Add support for array as root object in JSON

### DIFF
--- a/Serpent/Serpent.xcodeproj/project.pbxproj
+++ b/Serpent/Serpent.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		0124E1111F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
 		0124E1121F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
 		0124E1131F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
+		016C12401F28065D00A4FCED /* BadArrayTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 016C123F1F28065D00A4FCED /* BadArrayTest.json */; };
+		016C12411F28065D00A4FCED /* BadArrayTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 016C123F1F28065D00A4FCED /* BadArrayTest.json */; };
+		016C12421F28065D00A4FCED /* BadArrayTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 016C123F1F28065D00A4FCED /* BadArrayTest.json */; };
 		01BBEFD41DE1D52D003AC718 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFD01DE1D50F003AC718 /* Alamofire.framework */; };
 		01BBEFD51DE1D52D003AC718 /* Cashier.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFD21DE1D50F003AC718 /* Cashier.framework */; };
 		01BBEFD61DE1D533003AC718 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFCB1DE1D50F003AC718 /* Alamofire.framework */; };
@@ -194,6 +197,7 @@
 
 /* Begin PBXFileReference section */
 		0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArrayTestOneObject.json; sourceTree = "<group>"; };
+		016C123F1F28065D00A4FCED /* BadArrayTest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = BadArrayTest.json; sourceTree = "<group>"; };
 		01BBEFB31DE1D50E003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		01BBEFB61DE1D50F003AC718 /* Cashier.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Cashier.framework; sourceTree = "<group>"; };
 		01BBEFBE1DE1D50F003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
@@ -515,6 +519,7 @@
 				830175AD1D96E8A700B85378 /* NetworkModel.json */,
 				830175A01D96E44100B85378 /* ArrayTest.json */,
 				0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */,
+				016C123F1F28065D00A4FCED /* BadArrayTest.json */,
 				830175A11D96E44100B85378 /* Empty.json */,
 				830175A21D96E44100B85378 /* NestedArrayTest.json */,
 				830175B31D96E9D000B85378 /* NetworkModelBad.json */,
@@ -770,6 +775,7 @@
 				830175BF1D97008800B85378 /* PerformanceSmallTest.json in Resources */,
 				272D92751C6DFB7300BCD3B6 /* EnumsTest.json in Resources */,
 				0124E1111F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
+				016C12401F28065D00A4FCED /* BadArrayTest.json in Resources */,
 				272D92771C6DFB7300BCD3B6 /* PrimitivesTest.json in Resources */,
 				01C706D21C9BEB0C0024E94A /* DecodableTest.json in Resources */,
 				830175B41D96E9D000B85378 /* NetworkModelBad.json in Resources */,
@@ -807,6 +813,7 @@
 				830175C11D97008800B85378 /* PerformanceSmallTest.json in Resources */,
 				2732ECD41C9F2A4D00BFD4E1 /* StringInitializableTest.json in Resources */,
 				0124E1131F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
+				016C12421F28065D00A4FCED /* BadArrayTest.json in Resources */,
 				2732ECD51C9F2A4D00BFD4E1 /* HexInitializableTest.json in Resources */,
 				2732ECD61C9F2A4D00BFD4E1 /* SerializableEntityTest.json in Resources */,
 				830175B61D96E9D000B85378 /* NetworkModelBad.json in Resources */,
@@ -837,6 +844,7 @@
 				830175B51D96E9D000B85378 /* NetworkModelBad.json in Resources */,
 				2785B5621C9DE9A400E40605 /* PrimitivesTest.json in Resources */,
 				0124E1121F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
+				016C12411F28065D00A4FCED /* BadArrayTest.json in Resources */,
 				830175AA1D96E44100B85378 /* NestedArrayTest.json in Resources */,
 				830175C31D97008800B85378 /* PerformanceTest.json in Resources */,
 				2785B5631C9DE9A400E40605 /* StringInitializableTest.json in Resources */,

--- a/Serpent/Serpent.xcodeproj/project.pbxproj
+++ b/Serpent/Serpent.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0124E1111F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
+		0124E1121F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
+		0124E1131F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */; };
 		01BBEFD41DE1D52D003AC718 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFD01DE1D50F003AC718 /* Alamofire.framework */; };
 		01BBEFD51DE1D52D003AC718 /* Cashier.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFD21DE1D50F003AC718 /* Cashier.framework */; };
 		01BBEFD61DE1D533003AC718 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBEFCB1DE1D50F003AC718 /* Alamofire.framework */; };
@@ -190,6 +193,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArrayTestOneObject.json; sourceTree = "<group>"; };
 		01BBEFB31DE1D50E003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		01BBEFB61DE1D50F003AC718 /* Cashier.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Cashier.framework; sourceTree = "<group>"; };
 		01BBEFBE1DE1D50F003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
@@ -510,6 +514,7 @@
 			children = (
 				830175AD1D96E8A700B85378 /* NetworkModel.json */,
 				830175A01D96E44100B85378 /* ArrayTest.json */,
+				0124E1101F2803CB00FCD29C /* ArrayTestOneObject.json */,
 				830175A11D96E44100B85378 /* Empty.json */,
 				830175A21D96E44100B85378 /* NestedArrayTest.json */,
 				830175B31D96E9D000B85378 /* NetworkModelBad.json */,
@@ -764,6 +769,7 @@
 				01C706CB1C9BEB0C0024E94A /* HexInitializableTest.json in Resources */,
 				830175BF1D97008800B85378 /* PerformanceSmallTest.json in Resources */,
 				272D92751C6DFB7300BCD3B6 /* EnumsTest.json in Resources */,
+				0124E1111F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
 				272D92771C6DFB7300BCD3B6 /* PrimitivesTest.json in Resources */,
 				01C706D21C9BEB0C0024E94A /* DecodableTest.json in Resources */,
 				830175B41D96E9D000B85378 /* NetworkModelBad.json in Resources */,
@@ -800,6 +806,7 @@
 				2732ECD31C9F2A4D00BFD4E1 /* PrimitivesTest.json in Resources */,
 				830175C11D97008800B85378 /* PerformanceSmallTest.json in Resources */,
 				2732ECD41C9F2A4D00BFD4E1 /* StringInitializableTest.json in Resources */,
+				0124E1131F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
 				2732ECD51C9F2A4D00BFD4E1 /* HexInitializableTest.json in Resources */,
 				2732ECD61C9F2A4D00BFD4E1 /* SerializableEntityTest.json in Resources */,
 				830175B61D96E9D000B85378 /* NetworkModelBad.json in Resources */,
@@ -829,6 +836,7 @@
 				830175C01D97008800B85378 /* PerformanceSmallTest.json in Resources */,
 				830175B51D96E9D000B85378 /* NetworkModelBad.json in Resources */,
 				2785B5621C9DE9A400E40605 /* PrimitivesTest.json in Resources */,
+				0124E1121F2803CB00FCD29C /* ArrayTestOneObject.json in Resources */,
 				830175AA1D96E44100B85378 /* NestedArrayTest.json in Resources */,
 				830175C31D97008800B85378 /* PerformanceTest.json in Resources */,
 				2785B5631C9DE9A400E40605 /* StringInitializableTest.json in Resources */,

--- a/Serpent/Serpent/Classes/Extensions/AlamofireExtension.swift
+++ b/Serpent/Serpent/Classes/Extensions/AlamofireExtension.swift
@@ -41,10 +41,8 @@ public extension Parser {
             case .failure(let error):
                 //TODO: Add stubbed request for testing response not being empty
                 var responseDict = [NSLocalizedDescriptionKey : "Serialization failed!"]
-                if let response = response {
-                    responseDict["response"] = "\(response)"
-                    responseDict["error"] = "\(error)"
-                }
+                responseDict["error"] = "\(error.localizedDescription)"
+                responseDict["response"] = String(describing: response)
                 return .failure(NSError(domain: "Serializable.Parser", code: 2048, userInfo: responseDict))
             }
         }

--- a/Serpent/SerpentTests/Models/PrimitivesTestModel.swift
+++ b/Serpent/SerpentTests/Models/PrimitivesTestModel.swift
@@ -96,8 +96,8 @@ extension PrimitivesTestModel:Serializable {
         dict["optional_bool"]                                = optionalBool
         dict["optional_bool_with_default_value"]             = optionalBoolWithDefaultValue
         dict["char"]                                         = "\(char)"
-        dict["optional_char"]                                = optionalChar != nil ? "\(optionalChar!)" : "\(optionalChar)"
-        dict["optional_char_with_default_value"]             = optionalCharWithDefaultValue != nil ? "\(optionalCharWithDefaultValue!)" : "\(optionalCharWithDefaultValue)"
+        dict["optional_char"]                                = optionalChar != nil ? "\(optionalChar!)" : "\(String(describing: optionalChar))"
+        dict["optional_char_with_default_value"]             = optionalCharWithDefaultValue != nil ? "\(optionalCharWithDefaultValue!)" : "\(String(describing: optionalCharWithDefaultValue))"
         dict["string"]                                       = string
         dict["optional_string"]                              = optionalString
         dict["optional_string_with_default_value"]           = optionalStringWithDefaultValue

--- a/Serpent/SerpentTests/TestEndpoint/ArrayTest.json
+++ b/Serpent/SerpentTests/TestEndpoint/ArrayTest.json
@@ -1,24 +1,21 @@
-
-[
-	 {
-	   "id" : 1,
-	   "name" : "Hello",
-	   "text" : "some text"
-	 },
-	 {
-	   "id" : 2,
-	   "name" : "Hello2",
-	   "text" : "some text2"
-	 },
-	 {
-	   "id" : 3,
-	   "name" : "Hello3",
-	   "text" : "some text3"
-	 },
-	 {
-	   "id" : 4,
-	   "name" : "Hello4",
-	   "text" : "some text4"
-	 }
-  ]
-
+[{
+    "id": 1,
+    "name": "Hello",
+    "text": "some text"
+},
+{
+    "id": 2,
+    "name": "Hello2",
+    "text": "some text2"
+},
+{
+    "id": 3,
+    "name": "Hello3",
+    "text": "some text3"
+},
+{
+    "id": 4,
+    "name": "Hello4",
+    "text": "some text4"
+}
+]

--- a/Serpent/SerpentTests/TestEndpoint/ArrayTestOneObject.json
+++ b/Serpent/SerpentTests/TestEndpoint/ArrayTestOneObject.json
@@ -1,0 +1,6 @@
+[{
+"id": 1,
+"name": "Hello",
+"text": "some text"
+}
+]

--- a/Serpent/SerpentTests/Tests/AlamofireExtensionTests.swift
+++ b/Serpent/SerpentTests/Tests/AlamofireExtensionTests.swift
@@ -78,7 +78,8 @@ class AlamofireExtensionTests: XCTestCase {
 		}
 		waitForExpectations(timeout: timeoutDuration, handler: nil)
 	}
-	func testAlamofireExtensionUnexpectedArrayJSON() {
+
+    func testAlamofireExtensionUnexpectedArrayJSON() {
 		let expectation = self.expectation(description: "Expected array data to single object from response")
 		let handler:(Alamofire.DataResponse<DecodableModel>) -> Void = { result in
 			switch result.result {
@@ -93,6 +94,7 @@ class AlamofireExtensionTests: XCTestCase {
 		}
 		waitForExpectations(timeout: timeoutDuration, handler: nil)
 	}
+
 	func testAlamofireExtensionEmptyJSON() {
 		let expectation = self.expectation(description: "Expected empty response")
 		let handler:(Alamofire.DataResponse<NetworkTestModel>) -> Void = { result in
@@ -143,6 +145,7 @@ class AlamofireExtensionTests: XCTestCase {
 		}
 		waitForExpectations(timeout: timeoutDuration, handler: nil)
 	}
+
 	func testAlamofireWrongTypeUnwrapper() {
 		let expectation = self.expectation(description: "Expected unwrapped array response")
 		let handler:(Alamofire.DataResponse<DecodableModel>) -> Void = { result in
@@ -174,6 +177,45 @@ class AlamofireExtensionTests: XCTestCase {
 		if let url = urlForResource(resource: "Empty") {
 			manager.request(url, method: .get).responseSerializable(handler)
 		}
+        waitForExpectations(timeout: timeoutDuration, handler: nil)
+    }
+
+    func testAlamofireExtensionArrayRootObjectParsingToOne() {
+        let expectation = self.expectation(description: "Expected valid object")
+        let handler:(Alamofire.DataResponse<DecodableModel>) -> Void = { result in
+            switch result.result {
+            case .success(let value):
+                XCTAssertEqual(value.id, 1)
+                XCTAssertEqual(value.name, "Hello")
+                expectation.fulfill()
+            default:
+                break
+            }
+        }
+        if let url = urlForResource(resource: "ArrayTestOneObject") {
+            manager.request(url, method: .get).responseSerializable(handler)
+        }
+        waitForExpectations(timeout: timeoutDuration, handler: nil)
+    }
+
+    func testAlamofireExtensionArrayRootObjectParsingToMultiple() {
+        let expectation = self.expectation(description: "Expected valid array")
+        let handler:(Alamofire.DataResponse<[DecodableModel]>) -> Void = { result in
+            switch result.result {
+            case .success(let values):
+                XCTAssertEqual(values.count, 4)
+                XCTAssertEqual(values[0].id, 1)
+                XCTAssertEqual(values[0].name, "Hello")
+                XCTAssertEqual(values[3].id, 4)
+                XCTAssertEqual(values[3].name, "Hello4")
+                expectation.fulfill()
+            default:
+                break
+            }
+        }
+        if let url = urlForResource(resource: "ArrayTest") {
+            manager.request(url, method: .get).responseSerializable(handler)
+        }
         waitForExpectations(timeout: timeoutDuration, handler: nil)
     }
 }

--- a/Serpent/SerpentTests/Tests/AlamofireExtensionTests.swift
+++ b/Serpent/SerpentTests/Tests/AlamofireExtensionTests.swift
@@ -198,6 +198,25 @@ class AlamofireExtensionTests: XCTestCase {
         waitForExpectations(timeout: timeoutDuration, handler: nil)
     }
 
+    func testAlamofireExtensionArrayRootObjectParsingToOneWithWrongUnwrapper() {
+        let expectation = self.expectation(description: "Expected valid object")
+        let handler:(Alamofire.DataResponse<DecodableModel>) -> Void = { result in
+            switch result.result {
+            case .success(let value):
+                XCTAssertEqual(value.id, 1)
+                XCTAssertEqual(value.name, "Hello")
+                expectation.fulfill()
+            default:
+                break
+            }
+        }
+        if let url = urlForResource(resource: "ArrayTestOneObject") {
+            manager.request(url, method: .get).responseSerializable(handler,
+                                                                    unwrapper: { return $0.0["nonexistent"] })
+        }
+        waitForExpectations(timeout: timeoutDuration, handler: nil)
+    }
+
     func testAlamofireExtensionArrayRootObjectParsingToMultiple() {
         let expectation = self.expectation(description: "Expected valid array")
         let handler:(Alamofire.DataResponse<[DecodableModel]>) -> Void = { result in


### PR DESCRIPTION
Extends the Alamofire extension so that a JSON that has an array as a root
object is considered valid and parses correctly. Additionally, also correctly
parses a single object if the response JSON contains only one dictionary
object in the root array object.

The new additions are unit tested and confirmed working. Some project warnings
were also fixed during the process.