### PR TITLE
Adding a locale to date formatter to remove issue of not parsing when…

### DIFF
--- a/Serpent/Serpent/Classes/Extensions/Extensions.swift
+++ b/Serpent/Serpent/Classes/Extensions/Extensions.swift
@@ -27,7 +27,11 @@ extension URL: StringInitializable {
 }
 
 extension Date: StringInitializable {
-    static fileprivate let internalDateFormatter = DateFormatter()
+    static fileprivate var internalDateFormatter : DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        return dateFormatter
+    }
     static fileprivate let allowedDateFormats = ["yyyy-MM-dd'T'HH:mm:ssZZZZZ", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd"]
 	static public var customDateFormats: [String] = []
 


### PR DESCRIPTION
… users device is set to 12 hour time

Having an issue where the dates are not parsing when the users device time is set to 12 hour.

Found this in the apple docs that seemed to fix it locally for me;
“If you’re working with fixed-format dates, you should first set the locale of the date formatter to something appropriate for your fixed format. In most cases the best locale to choose is en_US_POSIX, a locale that’s specifically designed to yield US English results regardless of both user and system preferences. en_US_POSIX is also invariant in time (if the US, at some point in the future, changes the way it formats dates, en_US will change to reflect the new behavior, but en_US_POSIX will not), and between platforms (en_US_POSIX works the same on iPhone OS as it does on OS X, and as it does on other platforms).”